### PR TITLE
Distinguish error for stop order without market price

### DIFF
--- a/matchengine/me_market.c
+++ b/matchengine/me_market.c
@@ -1027,6 +1027,9 @@ static int trigger_sell_stop_orders(bool real, market_t *m)
         if (mpd_cmp(m->last_price, order->trigger, &mpd_ctx) >= 0) {
             break;
         }
+        if (real) {
+            push_order_message(ORDER_EVENT_FINISH, order, m);
+        }
         if (order->type == MARKET_ORDER_TYPE_STOP_MARKET) {
             ret = put_market_order(real, &result, m, order->user_id, MARKET_ORDER_SIDE_ASK, order->amount, order->taker_fee, order->source);
         } else {
@@ -1053,6 +1056,9 @@ static int trigger_buy_stop_orders(bool real, market_t *m)
         order_t *order = node->value;
         if (mpd_cmp(m->last_price, order->trigger, &mpd_ctx) <= 0) {
             break;
+        }
+        if (real) {
+            push_order_message(ORDER_EVENT_FINISH, order, m);
         }
         if (order->type == MARKET_ORDER_TYPE_STOP_MARKET) {
             ret = put_market_order(real, &result, m, order->user_id, MARKET_ORDER_SIDE_BID, order->amount, order->taker_fee, order->source);

--- a/matchengine/me_market.c
+++ b/matchengine/me_market.c
@@ -1078,8 +1078,11 @@ static int trigger_buy_stop_orders(bool real, market_t *m)
 
 int market_put_stop_market_order(bool real, json_t **result, market_t *m, uint32_t user_id, uint32_t side, mpd_t *trigger, mpd_t *amount, mpd_t *taker_fee, const char *source)
 {
+    if (m->last_price->len == 0) {
+        return -102;
+    }
     if (side == MARKET_ORDER_SIDE_ASK) {
-        if (m->last_price->len == 0 || mpd_cmp(trigger, m->last_price, &mpd_ctx) >= 0) {
+        if (mpd_cmp(trigger, m->last_price, &mpd_ctx) >= 0) {
             return -101;
         }
         mpd_t *balance = balance_get(user_id, BALANCE_TYPE_AVAILABLE, m->stock);
@@ -1090,7 +1093,7 @@ int market_put_stop_market_order(bool real, json_t **result, market_t *m, uint32
             return -2;
         }
     } else {
-        if (m->last_price->len == 0 || mpd_cmp(trigger, m->last_price, &mpd_ctx) <= 0) {
+        if (mpd_cmp(trigger, m->last_price, &mpd_ctx) <= 0) {
             return -101;
         }
         mpd_t *balance = balance_get(user_id, BALANCE_TYPE_AVAILABLE, m->money);
@@ -1165,8 +1168,11 @@ int market_put_stop_market_order(bool real, json_t **result, market_t *m, uint32
 
 int market_put_stop_limit_order(bool real, json_t **result, market_t *m, uint32_t user_id, uint32_t side, mpd_t *trigger, mpd_t *amount, mpd_t *price, mpd_t *taker_fee, mpd_t *maker_fee, const char *source)
 {
+    if (m->last_price->len == 0) {
+        return -102;
+    }
     if (side == MARKET_ORDER_SIDE_ASK) {
-        if (m->last_price->len == 0 || mpd_cmp(trigger, m->last_price, &mpd_ctx) >= 0) {
+        if (mpd_cmp(trigger, m->last_price, &mpd_ctx) >= 0) {
             return -101;
         }
         mpd_t *balance = balance_get(user_id, BALANCE_TYPE_AVAILABLE, m->stock);
@@ -1177,7 +1183,7 @@ int market_put_stop_limit_order(bool real, json_t **result, market_t *m, uint32_
             return -2;
         }
     } else {
-        if (m->last_price->len == 0 || mpd_cmp(trigger, m->last_price, &mpd_ctx) <= 0) {
+        if (mpd_cmp(trigger, m->last_price, &mpd_ctx) <= 0) {
             return -101;
         }
         mpd_t *balance = balance_get(user_id, BALANCE_TYPE_AVAILABLE, m->money);

--- a/matchengine/me_server.c
+++ b/matchengine/me_server.c
@@ -425,6 +425,8 @@ static int on_cmd_order_put_stop_market(nw_ses *ses, rpc_pkg *pkg, json_t *param
         return reply_error(ses, pkg, 11, "amount too small");
     } else if (ret == -101) {
         return reply_error(ses, pkg, 101, "stop price outside market price");
+    } else if (ret == -102) {
+        return reply_error(ses, pkg, 102, "market price has not yet been initialized");
     } else if (ret < 0) {
         log_fatal("market_put_stop_market_order fail: %d", ret);
         return reply_error_internal_error(ses, pkg);
@@ -534,6 +536,8 @@ static int on_cmd_order_put_stop_limit(nw_ses *ses, rpc_pkg *pkg, json_t *params
         return reply_error(ses, pkg, 11, "amount too small");
     } else if (ret == -101) {
         return reply_error(ses, pkg, 101, "stop price outside market price");
+    } else if (ret == -102) {
+        return reply_error(ses, pkg, 102, "market price has not yet been initialized");
     } else if (ret < 0) {
         log_fatal("market_put_stop_limit_order fail: %d", ret);
         return reply_error_internal_error(ses, pkg);


### PR DESCRIPTION
Assigns a unique error code and message to the case of a stop order without market price.